### PR TITLE
Fix Docker HEALTHCHECK: use python instead of pgrep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN pip list
 RUN mkdir /logs && chmod 777 /logs
 
 HEALTHCHECK --interval=30s --timeout=10s --retries=3 \
-  CMD pgrep -f inverter_hid.py || exit 1
+  CMD python -c "import os; os.kill(1, 0)" || exit 1
 
 # Run inverter_hid.py when the container launches
 CMD ["python", "./inverter_hid.py"]


### PR DESCRIPTION
## Summary

- Fix `HEALTHCHECK` command in Dockerfile — `pgrep` is not available in `python:3.11-slim`, causing the container to always report as `unhealthy`
- Uses `python -c "import os; os.kill(1, 0)"` to check if PID 1 (main process) is alive instead

## Test plan

- [ ] Merge and wait for image build
- [ ] Pull new image on Pi: `docker pull serjtf/inverter:latest`
- [ ] Restart container and verify `docker ps` shows `(healthy)` after ~60s

🤖 Generated with [Claude Code](https://claude.com/claude-code)